### PR TITLE
package.json license should match readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/yeoman/generator-dummy.git"
   },
   "author": "Simon Boudrias",
-  "license": "MIT",
+  "license": "BSD",
   "bugs": {
     "url": "https://github.com/yeoman/generator-dummy/issues"
   }


### PR DESCRIPTION
Presumably, the readme is correct (BSD). The majority of the yeoman utilities
are all BSD so I'm assuming this is as well, despite package.json stating MIT.
